### PR TITLE
Experiment packet capture changes

### DIFF
--- a/cmd/bidi/dns.go
+++ b/cmd/bidi/dns.go
@@ -7,10 +7,13 @@ import (
 	"log"
 	"math/rand"
 	"net"
+	"os"
+	"path/filepath"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"github.com/google/gopacket/pcapgo"
 	"github.com/miekg/dns"
 )
 
@@ -19,6 +22,8 @@ const dnsProbeTypeName = "dns"
 type dnsProber struct {
 	sender *udpSender
 	qType  uint
+
+	outDir string
 }
 
 func (p *dnsProber) registerFlags() {
@@ -70,14 +75,19 @@ func (p *dnsProber) buildPayload(name string) ([]byte, error) {
 }
 
 func (p *dnsProber) handlePcap(iface string) {
+	f, _ := os.Create(filepath.Join(p.outDir, "dns.pcap"))
+	w := pcapgo.NewWriter(f)
+	w.WriteFileHeader(1600, layers.LinkTypeEthernet)
+	defer f.Close()
 
 	if handle, err := pcap.OpenLive(iface, 1600, true, pcap.BlockForever); err != nil {
 		panic(err)
-	} else if err := handle.SetBPFFilter("udp src port 53"); err != nil { // optional
+	} else if err := handle.SetBPFFilter("icmp or udp src port 53"); err != nil { // optional
 		panic(err)
 	} else {
 		packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
 		for packet := range packetSource.Packets() {
+			w.WritePacket(packet.Metadata().CaptureInfo, packet.Data())
 			p.handlePacket(packet)
 		}
 	}
@@ -87,6 +97,7 @@ func (p *dnsProber) handlePcap(iface string) {
 func (p *dnsProber) handlePacket(packet gopacket.Packet) {
 	udpLayer := packet.Layer(layers.LayerTypeUDP)
 	if udpLayer == nil {
+		// could happen with ICMP packets. Ignore in processing.
 		return
 	}
 	udp, _ := udpLayer.(*layers.UDP)

--- a/cmd/bidi/http.go
+++ b/cmd/bidi/http.go
@@ -60,7 +60,7 @@ func (p *httpProber) handlePcap(iface string) {
 
 	if handle, err := pcap.OpenLive(iface, 1600, true, pcap.BlockForever); err != nil {
 		panic(err)
-	} else if err := handle.SetBPFFilter("tcp src port 80"); err != nil { // optional
+	} else if err := handle.SetBPFFilter("icmp or tcp src port 80"); err != nil { // optional
 		panic(err)
 	} else {
 		defer handle.Close()

--- a/cmd/bidi/main.go
+++ b/cmd/bidi/main.go
@@ -206,6 +206,7 @@ func main() {
 			log.Fatal(err)
 		}
 		prober.sender = u
+		prober.outDir = *outDir
 		defer u.clean()
 	}
 

--- a/cmd/bidi/quic.go
+++ b/cmd/bidi/quic.go
@@ -189,8 +189,8 @@ func (p *quicProber) handlePcap(iface string) {
 
 		packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
 		for packet := range packetSource.Packets() {
-			// p.handlePacket(packet)
 			w.WritePacket(packet.Metadata().CaptureInfo, packet.Data())
+			// p.handlePacket(packet)
 		}
 	}
 }

--- a/cmd/bidi/tls.go
+++ b/cmd/bidi/tls.go
@@ -66,7 +66,7 @@ func (p *tlsProber) handlePcap(iface string) {
 
 	if handle, err := pcap.OpenLive(iface, 1600, true, pcap.BlockForever); err != nil {
 		panic(err)
-	} else if err := handle.SetBPFFilter("tcp src port 443"); err != nil { // optional
+	} else if err := handle.SetBPFFilter("icmp or tcp src port 443"); err != nil { // optional
 		panic(err)
 	} else {
 		defer handle.Close()


### PR DESCRIPTION
We are slightly changing the way we capture packets during experiments to add a pcap for DNS experiments as well as capturing ICMP for all probes. 

This allows for a better understanding if something is going wrong in the send process. It also allows for the most in depth processing, i.e. looking at IP ttl in the injected DNS response packets.