### PR TITLE
Add ECH / ESNI Probes

### DIFF
--- a/cmd/bidi/main.go
+++ b/cmd/bidi/main.go
@@ -92,7 +92,8 @@ func main() {
 		dnsProbeTypeName:  &dnsProber{},
 		httpProbeTypeName: &httpProber{},
 		tlsProbeTypeName:  &tlsProber{},
-		echProbeTypeName:  &echProber{},
+		esniProbeTypeName: &echProber{esni: true, send1_3: true},
+		echProbeTypeName:  &echProber{ech: true, send1_3: true},
 		quicProbeTypeName: &quicProber{},
 		dtlsProbeTypeName: &dtlsProber{},
 	}


### PR DESCRIPTION
Creates two new probe types, `ech` and `esni` that send a TLS ClientHello with either the ECH or ESNI extensions in the packet. This is sent in the same way as the typical TLS probe so the `-nsa` & `-syn-delay` options are still valid. Domains from the input domain file are still included in the SNI extension as ECH / ESNI still include an outer SNI extension.  

I am thinking about adding the ability to modify the extension id for the ECH probe because ECH is an evolving proposal and the extension ID has already changed at least once. However, the current extension id is the valid one for the latest version (draft 14) and the previous version (draft 13) as the contents of the ClientHello extension didn't materially change. 

I did not necessarily follow the ESNI RFC, but it is properly parse-able using wireshark with proper fields randomizing.

ECH is not parsed by wireshark, but it does follow both the (draft) RFC and the pcap of the implementation in openssl by sftcd. 

## Example Command(s)

```sh
go build -a .
printf "138.197.211.159" | sudo ./bidi -domains domains.txt -iface wlp4s0 -laddr 10.0.0.0 -workers 1 -type esni -d out/esni -nsa
printf "138.197.211.159" | sudo ./bidi -domains domains.txt -iface wlp4s0 -laddr 10.0.0.0 -workers 1 -type ech -d out/ech
```

## References  

[ECH RFC draft 13](https://www.ietf.org/archive/id/draft-ietf-tls-esni-13.html)
[ECH RFC draft 14](https://www.ietf.org/archive/id/draft-ietf-tls-esni-14.html)  (latest as of 9/22)
[ESNI RFC](https://datatracker.ietf.org/doc/draft-ietf-tls-esni/06/) this is the last RFC titled ESNI before it becomes ECH - not sure if this is exactly what is implemented.
[OpenSSL ECH implementation (draft 13)](https://github.com/sftcd/openssl/blob/ECH-draft-13c/esnistuff/building-curl-openssl-with-ech.md) for testing and PCAP


closes #5 